### PR TITLE
feat: Component构造器允许识别额外参数，并作为对应实例的属性

### DIFF
--- a/packages/global/types/lib.component.d.ts
+++ b/packages/global/types/lib.component.d.ts
@@ -286,7 +286,17 @@ declare namespace MiniProgram.Component {
         Mixin.IMixin4Legacy | ReturnType<Mixin.Constructor>
       > = any[]
     >(
-      opts: Partial<IOptions<Data, Props, Methods, ExtraOptions, Mixins>> &
+      opts: {
+        [P in keyof ExtraOptions]: P extends keyof IOptions<
+          Data,
+          Props,
+          Methods,
+          ExtraOptions,
+          Mixins
+        >
+          ? unknown
+          : ExtraOptions[P];
+      } & Partial<IOptions<Data, Props, Methods, ExtraOptions, Mixins>> &
         ThisType<
           IInstance<
             Data,

--- a/tests/global/component.test.ts
+++ b/tests/global/component.test.ts
@@ -4,6 +4,7 @@ const mixin = Mixin({});
 
 Component({
   mixins: [],
+  test: 111,
   data() {
     expectAssignable<void>(this);
     return {
@@ -30,6 +31,7 @@ Component({
     expectAssignable<String>(this.is);
     expectAssignable<Object>(this.$page);
     expectAssignable<Number>(this.$id);
+    expectAssignable<Number>(this.test);
   },
   didMount() {
     expectType<number>(this.data.x);
@@ -159,3 +161,11 @@ Component({
     },
   }
 });
+
+
+Component<{}, {}, {}, {}, {test: number}>({
+  test: 111,
+  onInit() {
+    expectAssignable<Number>(this.test);
+  }
+})


### PR DESCRIPTION
fix #33 